### PR TITLE
Don't skip RDNs when reading from LDAP.  Just treat them like normal …

### DIFF
--- a/resource_ldap_object.go
+++ b/resource_ldap_object.go
@@ -332,14 +332,6 @@ func readLDAPObjectImpl(d *schema.ResourceData, meta interface{}, updateState bo
 			log.Printf("[DEBUG] ldap_object::read - skipping attribute %q of %q", attribute.Name, dn)
 			continue
 		}
-		if len(attribute.Values) == 1 {
-			// we don't treat the RDN as an ordinary attribute
-			a := fmt.Sprintf("%s=%s", attribute.Name, attribute.Values[0])
-			if strings.HasPrefix(dn, a) {
-				log.Printf("[DEBUG] ldap_object::read - skipping RDN %q of %q", a, dn)
-				continue
-			}
-		}
 		log.Printf("[DEBUG] ldap_object::read - adding attribute %q to %q (%d values)", attribute.Name, dn, len(attribute.Values))
 		// now add each value as an individual entry into the object, because
 		// we do not handle name => []values, and we have a set of maps each


### PR DESCRIPTION
…attributes.

Skipping RDNs was causing 'terraform apply' to always attempt to add the RDN attribute.
And when terraform attempted to add the RDN attribute, the ldap server would complain that the attribute already existed.

I didn't see a reason why RDNs should be skipped when reading from LDAP,
so I just removed the the logic to skip them.